### PR TITLE
Colour functions

### DIFF
--- a/anything.js
+++ b/anything.js
@@ -120,6 +120,41 @@
     }();
 
 
+    var RGBtoCMYK = function( rgb ) {
+        if ((typeof rgb) == "string" && rgb[0] == "#" && (rgb.length == 7 || rgb.length == 4)){
+            if (rgb.length == 4) {
+                rgb = "#"+rgb[1]+rgb[1]+rgb[2]+rgb[2]+rgb[3]+rgb[3];
+            }
+            newrgb = {r:0, g:0, b:0};
+            newrgb.r = parseInt(rgb.substring(1,3), 16);
+            newrgb.g = parseInt(rgb.substring(3,5), 16);
+            newrgb.b = parseInt(rgb.substring(5,8), 16);
+            rgb = newrgb;
+        }
+        var r = rgb['r']/255;
+        var g = rgb['g']/255;
+        var b = rgb['b']/255;
+        var k = 1 - (Math.max(r, g, b));
+        if (k != 1) {
+            var c = ((1 - r) - k) / (1 - k);
+            var m = ((1 - g) - k) / (1 - k);
+            var y = ((1 - b) - k) / (1 - k);
+        } else {
+            var c = 0;
+            var m = 0;
+            var y = 0;
+        }
+        return {c: c, m: m, y: y, k: k};
+    }
+
+    var CMYKtoRGB = function( cmyk ) {
+        var r = 255 * (1-cmyk.c) * (1-cmyk.k);
+        var g = 255 * (1-cmyk.m) * (1-cmyk.k);
+        var b = 255 * (1-cmyk.y) * (1-cmyk.k);
+        return {r: r, g: g, b: b};
+    }
+
+
     //prototypes go here
     anything.prototype.doTheThing = doTheThing;
     anything.prototype.flipText = flipText;
@@ -137,6 +172,8 @@
     anything.prototype.twoString = twoString;
     anything.prototype.fizzbuzz = fizzbuzz;
     anything.prototype.generateUniqueColorHue = generateUniqueColorHue;
+    anything.prototype.RGBtoCMYK = RGBtoCMYK;
+    anything.prototype.CMYKtoRGB = CMYKtoRGB;
 
     //put that shit where everyone can see it.
     if(typeof(window.Δ) === 'undefined'){

--- a/anything.js
+++ b/anything.js
@@ -119,6 +119,9 @@
         }
     }();
 
+    function negMod( n, m ) {
+        return ((n % m) + m) % m;
+    }
 
     var RGBtoCMYK = function( rgb ) {
         if ((typeof rgb) == "string" && rgb[0] == "#" && (rgb.length == 7 || rgb.length == 4)){
@@ -154,6 +157,110 @@
         return {r: r, g: g, b: b};
     }
 
+    var RGBtoHSL = function( rgb ) {
+        var r = rgb['r'] / 255;
+        var g = rgb['g'] / 255;
+        var b = rgb['b'] / 255;
+        var rgbOrdered = [r,g,b].sort();
+        var l = ((rgbOrdered[0] + rgbOrdered[2]) / 2) * 100;
+        var s, h;
+        if (rgbOrdered[0] == rgbOrdered[2]) {
+            s = 0;
+            h = 0;
+        } else {
+            if (l >= 50) {
+                s = ((rgbOrdered[2] - rgbOrdered[0])/((2.0 - rgbOrdered[2]) - rgbOrdered[0])) * 100;
+            } else {
+                s = ((rgbOrdered[2] - rgbOrdered[0])/(rgbOrdered[2] + rgbOrdered[0])) * 100;
+            }
+            if (rgbOrdered[2] == r) {
+                h = ((g-b)/(rgbOrdered[2] - rgbOrdered[0])) * 60;
+            } else if (rgbOrdered[2] == g) {
+                h = (2+((b-r)/(rgbOrdered[2] - rgbOrdered[0]))) * 60;
+            } else {
+                h = (4+((r-g)/(rgbOrdered[2] - rgbOrdered[0]))) * 60;
+            }
+            if (h < 0) {
+                h += 360;
+            } else if (h > 360) {
+                h = h % 360;
+            }
+        };
+        return {
+            h: h,
+            s: s,
+            l: l
+        };
+    }
+
+    var HSLtoRGB = function( hsl ) {
+        if (hsl.s == 0) {
+            var grey = (hsl.l / 100) * 255;
+            return {
+                r: grey,
+                g: grey,
+                b: grey
+            }
+        } else {
+            if (hsl.l >= 50) {
+                tempOne = ((hsl.l/100) + (hsl.s/100)) - ((hsl.l/100) * (hsl.s/100));
+            } else {
+                tempOne = (hsl.l/100) * (1 + (hsl.s/100));
+            }
+            tempTwo = (2 * (hsl.l/100)) - tempOne;
+            tempHue = hsl.h / 360;
+            tempR = (tempHue + 0.333) % 1;
+            tempG = tempHue;
+            tempB = negMod((tempHue - 0.333), 1);
+            var r,g,b;
+            if ((6 * tempR) < 1) {
+                r = tempTwo + ((tempOne - tempTwo) * 6 * tempR);
+            } else if ((2 * tempR) < 1) {
+                r = tempOne;
+            } else if ((3 * tempR) < 2) {
+                r = tempTwo + ((tempOne - tempTwo) * ((0.666 - tempR) * 6));
+            } else {
+                r = tempTwo;
+            }
+            if ((6 * tempG) < 1) {
+                g = tempTwo + ((tempOne - tempTwo) * 6 * tempG);
+            } else if ((2 * tempG) < 1) {
+                g = tempOne;
+            } else if ((3 * tempG) < 2) {
+                g = tempTwo + ((tempOne - tempTwo) * ((0.666 - tempG) * 6));
+            } else {
+                g = tempTwo;
+            }
+            if ((6 * tempB) < 1) {
+                b = tempTwo + ((tempOne - tempTwo) * 6 * tempB);
+            } else if ((2 * tempB) < 1) {
+                b = tempOne;
+            } else if ((3 * tempB) < 2) {
+                b = tempTwo + ((tempOne - tempTwo) * ((0.666 - tempB) * 6));
+            } else {
+                b = tempTwo;
+            }
+            if (r < 0) r = 0;
+            if (g < 0) g = 0;
+            if (b < 0) b = 0;
+            return {
+                r: r * 255,
+                g: g * 255,
+                b: b * 255
+            }
+        }
+    }
+
+    var CMYKtoHSL = function( cmyk ) {
+        var rgb = CMYKtoRGB(cmyk);
+        return RGBtoHSL(rgb);
+    }
+
+    var HSLtoCMYK = function( hsl ) {
+        var rgb = HSLtoRGB(hsl);
+        return RGBtoCMYK(rgb);
+    }
+
 
     //prototypes go here
     anything.prototype.doTheThing = doTheThing;
@@ -174,6 +281,10 @@
     anything.prototype.generateUniqueColorHue = generateUniqueColorHue;
     anything.prototype.RGBtoCMYK = RGBtoCMYK;
     anything.prototype.CMYKtoRGB = CMYKtoRGB;
+    anything.prototype.RGBtoHSL = RGBtoHSL;
+    anything.prototype.HSLtoRGB = HSLtoRGB;
+    anything.prototype.CMYKtoHSL = CMYKtoHSL;
+    anything.prototype.HSLtoCMYK = HSLtoCMYK;
 
     //put that shit where everyone can see it.
     if(typeof(window.Δ) === 'undefined'){

--- a/anything.js
+++ b/anything.js
@@ -158,6 +158,16 @@
     }
 
     var RGBtoHSL = function( rgb ) {
+        if ((typeof rgb) == "string" && rgb[0] == "#" && (rgb.length == 7 || rgb.length == 4)){
+            if (rgb.length == 4) {
+                rgb = "#"+rgb[1]+rgb[1]+rgb[2]+rgb[2]+rgb[3]+rgb[3];
+            }
+            newrgb = {r:0, g:0, b:0};
+            newrgb.r = parseInt(rgb.substring(1,3), 16);
+            newrgb.g = parseInt(rgb.substring(3,5), 16);
+            newrgb.b = parseInt(rgb.substring(5,8), 16);
+            rgb = newrgb;
+        }
         var r = rgb['r'] / 255;
         var g = rgb['g'] / 255;
         var b = rgb['b'] / 255;


### PR DESCRIPTION
Here's some functions that can convert colours between RGB, HSL, and CMYK colour systems! :3
Here are examples of the data types, RGBto\* can also accept a hexadecimal colour string.

``` javascript
Δ.RGBtoHSL( {
    r: 45, // 0 --> 255
    g: 65, // 0 --> 255
    b: 122 // 0 --> 255
} )
```

``` javascript
Δ.CMYKtoRGB( {
    c: 0.67,  // 0 --> 1
    m: 0.181, // 0 --> 1
    y: 0.112, // 0 --> 1
    k: 0.5    // 0 --> 1
} )
```

``` javascript
Δ.HSLtoCMYK( {
    h: 210, // 0 --> 255
    s: 25,  // 0 --> 100
    l: 73   // 0 --> 100
} )
```
