### PR TITLE
Remove builder links from the page

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -16,7 +16,6 @@
         </a>
         <a href="index.html" class="item">Home</a>
         <a href="playground.html" class="olive item">Playground</a>
-        <a href="builder.php" class="olive item">Package builder</a>
         <a class="pink active item">Documentation</a>
     </div>
 

--- a/playground.html
+++ b/playground.html
@@ -58,7 +58,6 @@
 		</a>
 		<a href="index.html" class="item">Home</a>
 		<a class="olive active item">Playground</a>
-		<a href="builder.php" class="olive item">Package builder</a>
 		<a href="documentation.html" class="pink item">Documentation</a>
 	</div>
 


### PR DESCRIPTION
GitHub pages dislikes php

When clicking the links, it just leads the user to download the file

dis is not good
