### PR TITLE
Add mocha and eslint to test for bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A javascript library that contains anything.",
   "main": "anything.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",
@@ -23,5 +23,9 @@
     "gulp-jsbeautifier": "^1.0.1",
     "gulp-jsfuck": "^0.2.1",
     "gulp-minify": "0.0.5"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.4",
+    "mocha-eslint": "^1.0.0"
   }
 }

--- a/test/eslint.js
+++ b/test/eslint.js
@@ -5,4 +5,8 @@ var paths = [
   'test/**/*.js',
 ];
 
-lint(paths);
+var options = {
+    formatter: 'compact'
+};
+
+lint(paths, options);

--- a/test/eslint.js
+++ b/test/eslint.js
@@ -1,0 +1,8 @@
+var lint = require('mocha-eslint');
+
+var paths = [
+  'src/**/*.js',
+  'test/**/*.js',
+];
+
+lint(paths);


### PR DESCRIPTION
You can now run `npm test` to check for bugs, could also use a CI tool to run for pull requests. 

As of now the only files that don't work as expected are in `src/constants/`, I'm not sure why the function is broken into two files but it's really weird IMO. Here are the files:

`start.js`:

```
(function(window){

    /*
                        _   _     _                _
       __ _ _ __  _   _| |_| |__ (_)_ __   __ _   (_)___
      / _` | '_ \| | | | __| '_ \| | '_ \ / _` |  | / __|
     | (_| | | | | |_| | |_| | | | | | | | (_| |_ | \__ \
      \__,_|_| |_|\__, |\__|_| |_|_|_| |_|\__, (_)/ |___/
                  |___/                   |___/ |__/
     */

    var anything = function() {
        this.version = "6.9.1"
    };

```

`end.js`:

```
//put that shit where everyone can see it.
    if(typeof(window.Δ) === 'undefined'){
        window.Δ = new anything();
    } else {
        console.log("Δ already defined.");
    }

})(window);
```
