### PR TITLE
Fix missing prototype function declaration

### DIFF
--- a/src/recursiveFunction.js
+++ b/src/recursiveFunction.js
@@ -6,3 +6,5 @@ var recursiveFunction = function recursiveFunction () {
         }
     }
 };
+
+anything.prototype.recursiveFunction = recursiveFunction;


### PR DESCRIPTION
I figured @justin-endler forgot to add it.
