### PR TITLE
Add `convertJSBooleanToCBoolean` utility function

### DIFF
--- a/src/convertJSBooleanToCBoolean.js
+++ b/src/convertJSBooleanToCBoolean.js
@@ -1,0 +1,17 @@
+/**
+ * Converts a JS boolean to a C boolean.
+ * @param {boolean} bool - a JS boolean.
+ * @return {number} C boolean.
+ * @author Vitor Cortez <vitoracortez+github@gmail.com>
+ */
+var convertJSBooleanToCBoolean = function(bool) {
+  if (bool === false && bool !== true) {
+    return 0;
+  } else if (bool === true && bool !== false) {
+    return 1;
+  } else {
+    return Infinity;
+  }
+};
+
+anything.prototype.convertJSBooleanToCBoolean = convertJSBooleanToCBoolean;


### PR DESCRIPTION
Because you never know when you might need C booleans values on the web.
